### PR TITLE
feat: add Debian Linux compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,13 @@
 *~
 \#*\#
 
-# Local overrides
+# Local overrides (e.g. .zshrc.local, .gitconfig.local)
 *.local
+!.local
 *.secrets
 
 # Tmux plugins (managed by TPM)
 tmux/.config/tmux/plugins/
+
+# Feature eval space
+plan/

--- a/.stow-local-ignore
+++ b/.stow-local-ignore
@@ -9,3 +9,4 @@ setup\.sh
 shared
 scripts
 tests
+plan

--- a/scripts/install-packages.sh
+++ b/scripts/install-packages.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+#
+# install-packages.sh - install CLI tools on Debian/Ubuntu
+#
+# Called by setup.sh on Linux. Installs apt packages and tools that need
+# alternative installation methods (AppImage, installer scripts, etc.).
+#
+# Usage: install-packages.sh --profile <server|desktop|wsl>
+
+set -euo pipefail
+
+info() { printf "[INFO] %s\n" "$1"; }
+warn() { printf "[WARN] %s\n" "$1" >&2; }
+error() { printf "[ERROR] %s\n" "$1" >&2; }
+
+PROFILE=""
+ARCH=$(dpkg --print-architecture 2>/dev/null || uname -m)
+
+# Normalize architecture names for GitHub releases
+case "${ARCH}" in
+  amd64|x86_64)  ARCH_GO="amd64"; ARCH_RUST="x86_64"; ARCH_GH="x86_64" ;;
+  arm64|aarch64) ARCH_GO="arm64"; ARCH_RUST="aarch64"; ARCH_GH="arm64" ;;
+  *) warn "Unsupported architecture: ${ARCH}"; ARCH_GO="${ARCH}"; ARCH_RUST="${ARCH}"; ARCH_GH="${ARCH}" ;;
+esac
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --profile) PROFILE="${2:-}"; shift 2 ;;
+    *) error "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "${PROFILE}" ]]; then
+  error "Usage: install-packages.sh --profile <server|desktop|wsl>"
+  exit 1
+fi
+
+# Fetch latest GitHub release tag (strips leading 'v')
+github_latest_version() {
+  local repo="$1"
+  curl -fsSL "https://api.github.com/repos/${repo}/releases/latest" \
+    | grep '"tag_name"' | head -1 | sed -E 's/.*"v?([^"]+)".*/\1/'
+}
+
+# --- apt packages -----------------------------------------------------------
+
+install_apt_packages() {
+  info "Updating apt package lists..."
+  sudo apt update -qq
+
+  local packages=(
+    bash
+    bat
+    btop
+    cmake
+    curl
+    fd-find
+    fzf
+    gcc
+    git
+    htop
+    jq
+    less
+    ripgrep
+    shellcheck
+    stow
+    tmux
+    tree
+    wget
+    zsh
+    zoxide
+  )
+
+  info "Installing apt packages..."
+  sudo apt install -y "${packages[@]}"
+}
+
+# --- Binary name symlinks ----------------------------------------------------
+
+install_symlinks() {
+  local bin_dir="${HOME}/.local/bin"
+  mkdir -p "${bin_dir}"
+
+  # batcat -> bat
+  if command -v batcat &>/dev/null && ! command -v bat &>/dev/null; then
+    ln -sf "$(command -v batcat)" "${bin_dir}/bat"
+    info "Symlinked batcat -> bat"
+  fi
+
+  # fdfind -> fd
+  if command -v fdfind &>/dev/null && ! command -v fd &>/dev/null; then
+    ln -sf "$(command -v fdfind)" "${bin_dir}/fd"
+    info "Symlinked fdfind -> fd"
+  fi
+}
+
+# --- Neovim (AppImage) ------------------------------------------------------
+
+install_neovim() {
+  if command -v nvim &>/dev/null; then
+    local ver
+    ver=$(nvim --version | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+    local major minor
+    major="${ver%%.*}"
+    minor="${ver#*.}"
+    if [[ "${major}" -gt 0 ]] || [[ "${minor}" -ge 9 ]]; then
+      info "Neovim already installed (v${ver})"
+      return
+    fi
+    warn "Neovim too old (v${ver}), upgrading via AppImage..."
+  fi
+
+  info "Installing Neovim AppImage..."
+  local tmp
+  tmp=$(mktemp -d)
+  curl -fsSL -o "${tmp}/nvim.appimage" \
+    "https://github.com/neovim/neovim/releases/latest/download/nvim.appimage"
+  chmod +x "${tmp}/nvim.appimage"
+  mv "${tmp}/nvim.appimage" "${HOME}/.local/bin/nvim"
+  rm -rf "${tmp}"
+  info "Neovim installed to ~/.local/bin/nvim"
+}
+
+# --- Starship ----------------------------------------------------------------
+
+install_starship() {
+  if command -v starship &>/dev/null; then
+    info "Starship already installed"
+    return
+  fi
+  info "Installing Starship..."
+  curl -fsSL https://starship.rs/install.sh | sh -s -- -y -b "${HOME}/.local/bin"
+}
+
+# --- mise (runtime version manager) -----------------------------------------
+
+install_mise() {
+  if command -v mise &>/dev/null; then
+    info "mise already installed"
+    return
+  fi
+  info "Installing mise..."
+  curl -fsSL https://mise.jdx.dev/install.sh | sh
+}
+
+# --- eza ---------------------------------------------------------------------
+
+install_eza() {
+  if command -v eza &>/dev/null; then
+    info "eza already installed"
+    return
+  fi
+  info "Installing eza..."
+  sudo mkdir -p /etc/apt/keyrings
+  wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc \
+    | sudo gpg --dearmor --yes -o /etc/apt/keyrings/gierens.gpg
+  echo "deb [signed-by=/etc/apt/keyrings/gierens.gpg] http://deb.gierens.de stable main" \
+    | sudo tee /etc/apt/sources.list.d/gierens.list >/dev/null
+  sudo apt update -qq
+  sudo apt install -y eza
+}
+
+# --- GitHub CLI --------------------------------------------------------------
+
+install_gh() {
+  if command -v gh &>/dev/null; then
+    info "GitHub CLI already installed"
+    return
+  fi
+  info "Installing GitHub CLI..."
+  sudo mkdir -p /etc/apt/keyrings
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+  echo "deb [arch=${ARCH} signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+  sudo apt update -qq
+  sudo apt install -y gh
+}
+
+# --- 1Password CLI -----------------------------------------------------------
+
+install_op() {
+  if command -v op &>/dev/null; then
+    info "1Password CLI already installed"
+    return
+  fi
+  info "Installing 1Password CLI..."
+  sudo mkdir -p /etc/apt/keyrings
+  curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
+    | sudo gpg --dearmor --yes -o /etc/apt/keyrings/1password.gpg
+  echo "deb [arch=${ARCH} signed-by=/etc/apt/keyrings/1password.gpg] https://downloads.1password.com/linux/debian/${ARCH} stable main" \
+    | sudo tee /etc/apt/sources.list.d/1password.list >/dev/null
+  sudo apt update -qq
+  sudo apt install -y 1password-cli
+}
+
+# --- diff-so-fancy -----------------------------------------------------------
+
+install_diff_so_fancy() {
+  if command -v diff-so-fancy &>/dev/null; then
+    info "diff-so-fancy already installed"
+    return
+  fi
+  if ! command -v npm &>/dev/null; then
+    warn "npm not found, skipping diff-so-fancy (install Node.js first via mise)"
+    return
+  fi
+  info "Installing diff-so-fancy..."
+  npm install -g diff-so-fancy
+}
+
+# --- lazygit -----------------------------------------------------------------
+
+install_lazygit() {
+  if command -v lazygit &>/dev/null; then
+    info "lazygit already installed"
+    return
+  fi
+  info "Installing lazygit..."
+  local version
+  version=$(github_latest_version "jesseduffield/lazygit")
+  local tmp
+  tmp=$(mktemp -d)
+  curl -fsSL -o "${tmp}/lazygit.tar.gz" \
+    "https://github.com/jesseduffield/lazygit/releases/download/v${version}/lazygit_${version}_Linux_${ARCH_GH}.tar.gz"
+  tar -xzf "${tmp}/lazygit.tar.gz" -C "${tmp}"
+  mv "${tmp}/lazygit" "${HOME}/.local/bin/lazygit"
+  rm -rf "${tmp}"
+  info "lazygit installed to ~/.local/bin/lazygit"
+}
+
+# --- git-quick-stats ---------------------------------------------------------
+
+install_git_quick_stats() {
+  if command -v git-quick-stats &>/dev/null; then
+    info "git-quick-stats already installed"
+    return
+  fi
+  info "Installing git-quick-stats..."
+  local tmp
+  tmp=$(mktemp -d)
+  git clone --depth 1 https://github.com/arzzen/git-quick-stats.git "${tmp}/gqs"
+  cp "${tmp}/gqs/git-quick-stats" "${HOME}/.local/bin/git-quick-stats"
+  chmod +x "${HOME}/.local/bin/git-quick-stats"
+  rm -rf "${tmp}"
+  info "git-quick-stats installed to ~/.local/bin/git-quick-stats"
+}
+
+# --- shfmt -------------------------------------------------------------------
+
+install_shfmt() {
+  if command -v shfmt &>/dev/null; then
+    info "shfmt already installed"
+    return
+  fi
+  info "Installing shfmt..."
+  local version
+  version=$(github_latest_version "mvdan/sh")
+  curl -fsSL -o "${HOME}/.local/bin/shfmt" \
+    "https://github.com/mvdan/sh/releases/download/v${version}/shfmt_v${version}_linux_${ARCH_GO}"
+  chmod +x "${HOME}/.local/bin/shfmt"
+  info "shfmt installed to ~/.local/bin/shfmt"
+}
+
+# --- tealdeer ----------------------------------------------------------------
+
+install_tealdeer() {
+  if command -v tldr &>/dev/null; then
+    info "tealdeer already installed"
+    return
+  fi
+  info "Installing tealdeer..."
+  local version
+  version=$(github_latest_version "tealdeer-rs/tealdeer")
+  curl -fsSL -o "${HOME}/.local/bin/tldr" \
+    "https://github.com/tealdeer-rs/tealdeer/releases/download/v${version}/tealdeer-linux-${ARCH_RUST}-musl"
+  chmod +x "${HOME}/.local/bin/tldr"
+  info "tealdeer installed to ~/.local/bin/tldr"
+}
+
+# --- yq ----------------------------------------------------------------------
+
+install_yq() {
+  if command -v yq &>/dev/null; then
+    info "yq already installed"
+    return
+  fi
+  info "Installing yq..."
+  local version
+  version=$(github_latest_version "mikefarah/yq")
+  curl -fsSL -o "${HOME}/.local/bin/yq" \
+    "https://github.com/mikefarah/yq/releases/download/v${version}/yq_linux_${ARCH_GO}"
+  chmod +x "${HOME}/.local/bin/yq"
+  info "yq installed to ~/.local/bin/yq"
+}
+
+# --- fastfetch ---------------------------------------------------------------
+
+install_fastfetch() {
+  if command -v fastfetch &>/dev/null; then
+    info "fastfetch already installed"
+    return
+  fi
+  info "Installing fastfetch..."
+  local version
+  version=$(github_latest_version "fastfetch-cli/fastfetch")
+  local tmp
+  tmp=$(mktemp -d)
+  curl -fsSL -o "${tmp}/fastfetch.deb" \
+    "https://github.com/fastfetch-cli/fastfetch/releases/download/${version}/fastfetch-linux-${ARCH_GO}.deb"
+  sudo dpkg -i "${tmp}/fastfetch.deb" || sudo apt install -f -y
+  rm -rf "${tmp}"
+}
+
+# --- Nerd Fonts (desktop only) -----------------------------------------------
+
+install_fonts() {
+  local font_dir="${HOME}/.local/share/fonts"
+  if fc-list 2>/dev/null | grep -qi "JetBrainsMono Nerd Font"; then
+    info "Nerd Fonts already installed"
+    return
+  fi
+
+  info "Installing JetBrains Mono Nerd Font..."
+  mkdir -p "${font_dir}"
+  local tmp
+  tmp=$(mktemp -d)
+
+  # JetBrains Mono
+  curl -fsSL -o "${tmp}/JetBrainsMono.tar.xz" \
+    "https://github.com/ryanoasis/nerd-fonts/releases/latest/download/JetBrainsMono.tar.xz"
+  tar -xf "${tmp}/JetBrainsMono.tar.xz" -C "${font_dir}"
+
+  # Symbols Only
+  if curl -fsSL -o "${tmp}/NerdFontsSymbolsOnly.tar.xz" \
+    "https://github.com/ryanoasis/nerd-fonts/releases/latest/download/NerdFontsSymbolsOnly.tar.xz" 2>/dev/null; then
+    tar -xf "${tmp}/NerdFontsSymbolsOnly.tar.xz" -C "${font_dir}" 2>/dev/null || true
+  fi
+
+  rm -rf "${tmp}"
+  fc-cache -f "${font_dir}" 2>/dev/null || true
+  info "Nerd Fonts installed to ${font_dir}"
+}
+
+# --- Main --------------------------------------------------------------------
+
+main() {
+  info "Installing packages for Debian (profile=${PROFILE})..."
+
+  # Core apt packages
+  install_apt_packages
+
+  # Binary name symlinks (bat, fd)
+  install_symlinks
+
+  # Tools needing alternative install methods
+  install_neovim
+  install_starship
+  install_mise
+  install_eza
+  install_gh
+  install_op
+  install_diff_so_fancy
+  install_lazygit
+  install_git_quick_stats
+  install_shfmt
+  install_tealdeer
+  install_yq
+  install_fastfetch
+
+  # Desktop-only packages
+  if [[ "${PROFILE}" == "desktop" ]]; then
+    install_fonts
+  fi
+
+  info "Package installation complete"
+}
+
+main

--- a/secrets/.local/bin/secrets
+++ b/secrets/.local/bin/secrets
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# secrets - load environment variables from 1Password into ~/.vars
+#
+# Authenticates via OP_SERVICE_ACCOUNT_TOKEN from ~/.secrets,
+# fetches fields from 1Password, and writes them as exports to ~/.vars.
+#
+# Usage:
+#   secrets --load [--vault NAME --item NAME]
+#   secrets --show    Display current ~/.vars contents
+#   secrets --help    Show this help message
+
+set -euo pipefail
+
+SECRETS_FILE="${HOME}/.secrets"
+VARS_FILE="${HOME}/.vars"
+VAULT=""
+ITEM=""
+
+info() { printf "[secrets] %s\n" "$1"; }
+error() { printf "[secrets] ERROR: %s\n" "$1" >&2; }
+
+show_help() {
+  cat <<EOF
+Usage: secrets <command> [options]
+
+Commands:
+  --load                 Fetch secrets from 1Password and write to ~/.vars
+  --show                 Display current ~/.vars contents
+  --help                 Show this help message
+
+Options (with --load):
+  --vault NAME           1Password vault name (one-time override)
+  --item NAME            1Password item name (one-time override)
+
+On first run, you'll be prompted for vault and item names.
+These are saved to ~/.secrets for subsequent runs.
+Use --vault/--item flags to override without changing saved config.
+
+Prerequisites:
+  - 1Password CLI (op) installed: brew install 1password-cli
+  - ~/.secrets file with: OP_SERVICE_ACCOUNT_TOKEN=<your-token>
+EOF
+}
+
+# Parse a value from ~/.secrets by key (handles KEY=val and export KEY=val)
+parse_secrets_value() {
+  local key="$1"
+  local raw
+  raw=$(grep -E "^(export[[:space:]]+)?${key}=" "${SECRETS_FILE}" 2>/dev/null | head -1 | sed 's/^export[[:space:]]*//' | cut -d= -f2-)
+  # Strip surrounding quotes (single or double)
+  raw="${raw#\"}" ; raw="${raw%\"}"
+  raw="${raw#\'}" ; raw="${raw%\'}"
+  printf '%s' "${raw}"
+}
+
+# Save a key=value pair to ~/.secrets (append if missing, update if exists)
+save_secrets_value() {
+  local key="$1" value="$2"
+  if grep -qE "^(export[[:space:]]+)?${key}=" "${SECRETS_FILE}" 2>/dev/null; then
+    local escaped
+    escaped=$(printf '%s\n' "${value}" | sed 's/[&/\]/\\&/g')
+    if [[ "$(uname)" == "Darwin" ]]; then
+      sed -i '' "s|^\(export[[:space:]]*\)\{0,1\}${key}=.*|${key}=${escaped}|" "${SECRETS_FILE}"
+    else
+      sed -i "s|^\(export[[:space:]]*\)\{0,1\}${key}=.*|${key}=${escaped}|" "${SECRETS_FILE}"
+    fi
+  else
+    echo "${key}=${value}" >> "${SECRETS_FILE}"
+  fi
+}
+
+check_prerequisites() {
+  if ! command -v op &>/dev/null; then
+    error "1Password CLI (op) not installed"
+    if [[ "$(uname)" == "Darwin" ]]; then
+      echo "  Install with: brew install 1password-cli" >&2
+    else
+      echo "  Install with: sudo apt install 1password-cli" >&2
+    fi
+    exit 1
+  fi
+
+  if ! command -v jq &>/dev/null; then
+    error "jq not installed"
+    if [[ "$(uname)" == "Darwin" ]]; then
+      echo "  Install with: brew install jq" >&2
+    else
+      echo "  Install with: sudo apt install jq" >&2
+    fi
+    exit 1
+  fi
+
+  if [[ ! -f "${SECRETS_FILE}" ]]; then
+    error "${SECRETS_FILE} not found"
+    echo "  Create it with: echo 'OP_SERVICE_ACCOUNT_TOKEN=<your-token>' > ${SECRETS_FILE}" >&2
+    echo "  Then secure it:  chmod 600 ${SECRETS_FILE}" >&2
+    exit 1
+  fi
+
+  local perms
+  if [[ "$(uname)" == "Darwin" ]]; then
+    perms=$(stat -f "%OLp" "${SECRETS_FILE}")
+  else
+    perms=$(stat -c "%a" "${SECRETS_FILE}")
+  fi
+  if [[ "${perms}" != "600" ]]; then
+    error "${SECRETS_FILE} has unsafe permissions (${perms}). Run: chmod 600 ${SECRETS_FILE}"
+    exit 1
+  fi
+}
+
+# Resolve vault/item: CLI flags > saved config > interactive prompt
+resolve_config() {
+  local saved_vault saved_item
+
+  saved_vault=$(parse_secrets_value "VAULT")
+  saved_item=$(parse_secrets_value "ITEM")
+
+  # CLI flags take priority (one-time override, don't save)
+  if [[ -n "${VAULT}" && -n "${ITEM}" ]]; then
+    return
+  fi
+
+  # Use saved config if available
+  if [[ -n "${saved_vault}" && -n "${saved_item}" ]]; then
+    VAULT="${saved_vault}"
+    ITEM="${saved_item}"
+    return
+  fi
+
+  # Interactive prompt on first run
+  info "First-run setup: configure 1Password source"
+  printf "  Vault name: " >&2
+  read -r VAULT
+  printf "  Item name: " >&2
+  read -r ITEM
+
+  if [[ -z "${VAULT}" || -z "${ITEM}" ]]; then
+    error "Vault and item names are required"
+    exit 1
+  fi
+
+  save_secrets_value "VAULT" "${VAULT}"
+  save_secrets_value "ITEM" "${ITEM}"
+  info "Saved vault=${VAULT}, item=${ITEM} to ${SECRETS_FILE}"
+}
+
+load_secrets() {
+  check_prerequisites
+
+  local token
+  token=$(parse_secrets_value "OP_SERVICE_ACCOUNT_TOKEN")
+  if [[ -z "${token}" ]]; then
+    error "OP_SERVICE_ACCOUNT_TOKEN not found in ${SECRETS_FILE}"
+    exit 1
+  fi
+  export OP_SERVICE_ACCOUNT_TOKEN="${token}"
+
+  resolve_config
+
+  info "Fetching secrets from 1Password (vault=${VAULT}, item=${ITEM})..."
+
+  local json
+  if ! json=$(op item get "${ITEM}" --vault "${VAULT}" --format json 2>/dev/null); then
+    error "Failed to fetch from 1Password (check token and vault/item names)"
+    exit 1
+  fi
+
+  # Parse fields: extract label/value pairs, skip empty values and section labels
+  local entries
+  entries=$(jq -r '
+    .fields[]
+    | select(.value != null and .value != "" and .type != "REFERENCE")
+    | "\(.label)=\(.value)"
+  ' <<< "${json}")
+
+  if [[ -z "${entries}" ]]; then
+    error "No secrets found in vault=${VAULT}, item=${ITEM}"
+    exit 1
+  fi
+
+  # Write to vars file
+  {
+    echo "# Generated by 'secrets --load' — do not edit manually"
+    echo "# Source: 1Password vault=${VAULT}, item=${ITEM}"
+    echo "# Updated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+    echo ""
+    while IFS='=' read -r key value; do
+      echo "export ${key}=\"${value}\""
+    done <<< "${entries}"
+  } > "${VARS_FILE}"
+
+  chmod 600 "${VARS_FILE}"
+
+  local count
+  count=$(printf '%s\n' "${entries}" | grep -c .)
+  info "Wrote ${count} variables to ${VARS_FILE}"
+  info "Run 'source ${VARS_FILE}' to load in current shell"
+}
+
+show_vars() {
+  if [[ ! -f "${VARS_FILE}" ]]; then
+    error "${VARS_FILE} not found — run 'secrets --load' first"
+    exit 1
+  fi
+  cat "${VARS_FILE}"
+}
+
+# Parse command and flags
+CMD=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --load)  CMD="load"; shift ;;
+    --show)  CMD="show"; shift ;;
+    --help)  CMD="help"; shift ;;
+    --vault) VAULT="${2:-}"; shift 2 ;;
+    --item)  ITEM="${2:-}"; shift 2 ;;
+    *)       show_help; exit 1 ;;
+  esac
+done
+
+# Validate --vault/--item usage
+if [[ -n "${VAULT}" || -n "${ITEM}" ]]; then
+  if [[ "${CMD}" != "load" ]]; then
+    error "--vault and --item can only be used with --load"
+    exit 1
+  fi
+  if [[ -z "${VAULT}" || -z "${ITEM}" ]]; then
+    error "--vault and --item must be used together"
+    exit 1
+  fi
+fi
+
+case "${CMD}" in
+  load) load_secrets ;;
+  show) show_vars ;;
+  help) show_help ;;
+  *)    show_help; exit 1 ;;
+esac

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 ################################################################################
 # setup.sh
@@ -11,28 +11,45 @@ set -e
 # Usage: ./setup.sh [OPTIONS]
 #
 # Options:
-#   --dry-run    Show what would be done without making changes
-#   --help       Show this help message
+#   --profile PROFILE  Linux profile: server (default), desktop, wsl
+#   --dry-run          Show what would be done without making changes
+#   --help             Show this help message
 ################################################################################
 
 DRY_RUN=false
 DOTFILES="${HOME}/dotfiles"
+OS=$(uname -s)
+PROFILE=""
 
 show_help() {
   cat <<EOF
 Usage: $0 [OPTIONS]
 
 Sets up dotfiles using GNU Stow for symlink management.
-Safe to run multiple times.
+Safe to run multiple times. Supports macOS and Debian Linux.
 
 Options:
-  --dry-run    Preview changes without applying them
-  --help       Show this help message
+  --profile PROFILE  Linux profile: server (default), desktop, wsl
+  --dry-run          Preview changes without applying them
+  --help             Show this help message
+
+Profiles:
+  macos    Auto-detected on macOS (do not set manually)
+  server   Headless Linux — CLI tools only (default on Linux)
+  desktop  Linux with GUI — includes Ghostty config and fonts
+  wsl      Windows Subsystem for Linux — same as server
+
+Examples:
+  ./setup.sh                       # macOS (auto-detected)
+  ./setup.sh --profile server      # Debian headless
+  ./setup.sh --profile desktop     # Debian with GUI
+  ./setup.sh --dry-run --profile server
 EOF
 }
 
 while [[ $# -gt 0 ]]; do
   case $1 in
+    --profile) PROFILE="$2"; shift 2 ;;
     --dry-run) DRY_RUN=true; shift ;;
     --help) show_help; exit 0 ;;
     *) echo "Unknown option: $1"; show_help; exit 1 ;;
@@ -63,27 +80,58 @@ backup_conflict() {
   fi
 }
 
+# Resolve profile from OS and flags
+resolve_profile() {
+  if [[ "${OS}" == "Darwin" ]]; then
+    if [[ -n "${PROFILE}" && "${PROFILE}" != "macos" ]]; then
+      error "--profile is not supported on macOS"
+      exit 1
+    fi
+    PROFILE="macos"
+  elif [[ -z "${PROFILE}" ]]; then
+    PROFILE="server"
+  fi
+
+  case "${PROFILE}" in
+    macos|server|desktop|wsl) ;;
+    *) error "Invalid profile: ${PROFILE}. Must be: server, desktop, or wsl"; exit 1 ;;
+  esac
+}
+
 main() {
+  resolve_profile
+
   if [[ "${DRY_RUN}" == "true" ]]; then
     printf "\n[DOTFILES] DRY RUN MODE - No changes will be made\n\n"
   fi
 
-  printf "\n[DOTFILES] Initializing dotfiles setup...\n\n"
+  printf "\n[DOTFILES] Initializing dotfiles setup (os=%s, profile=%s)...\n\n" "${OS}" "${PROFILE}"
 
   # Prerequisites
-  local osname
-  osname=$(uname)
-  if [ "${osname}" != "Darwin" ]; then
-    error "This script only supports macOS (got: ${osname})"
-    exit 1
-  fi
-
   if ! command -v stow >/dev/null; then
-    error "GNU Stow required. Install with: brew install stow"
+    if [[ "${OS}" == "Darwin" ]]; then
+      error "GNU Stow required. Install with: brew install stow"
+    else
+      error "GNU Stow required. Install with: sudo apt install stow"
+    fi
     exit 1
   fi
 
   info "Prerequisites OK"
+
+  # Install packages on Debian
+  if [[ "${OS}" == "Linux" && "${PROFILE}" != "macos" ]]; then
+    printf "\n[DOTFILES] Installing packages for Debian (%s)...\n\n" "${PROFILE}"
+    if [[ -f "${DOTFILES}/scripts/install-packages.sh" ]]; then
+      if [[ "${DRY_RUN}" == "true" ]]; then
+        info "[DRY RUN] Would run: scripts/install-packages.sh --profile ${PROFILE}"
+      else
+        bash "${DOTFILES}/scripts/install-packages.sh" --profile "${PROFILE}"
+      fi
+    else
+      warn "scripts/install-packages.sh not found, skipping package installation"
+    fi
+  fi
 
   # Create directories
   for dir in "${HOME}/.config" "${HOME}/.local/bin" "${HOME}/.ssh/keys"; do
@@ -112,7 +160,6 @@ main() {
   for item in "${stow_conflicts[@]}"; do
     local target="${HOME}/${item}"
     if [ -L "${target}" ]; then
-      # Remove stale symlinks not managed by stow
       local link_dest
       link_dest=$(readlink "${target}")
       if [[ "${link_dest}" != *"dotfiles/${item%%/*}"* ]] && [[ "${link_dest}" != "../dotfiles/"* ]] && [[ "${link_dest}" != "dotfiles/"* ]]; then
@@ -131,16 +178,25 @@ main() {
     info "Handled ${conflicts_found} conflicts"
   fi
 
-  # Stow packages
+  # Stow packages (profile-based selection)
   printf "\n[DOTFILES] Setting up symlinks with GNU Stow...\n\n"
 
   if [[ "${DRY_RUN}" == "false" ]]; then
     cd "${DOTFILES}"
   fi
 
+  local core_packages=(git nvim secrets starship tmux zsh)
+  local gui_packages=(ghostty)
+  local stow_packages=()
+
+  case "${PROFILE}" in
+    macos|desktop) stow_packages=("${core_packages[@]}" "${gui_packages[@]}") ;;
+    server|wsl)    stow_packages=("${core_packages[@]}") ;;
+  esac
+
   local packages=0
   local failed=0
-  for item in ghostty git nvim secrets starship tmux zsh; do
+  for item in "${stow_packages[@]}"; do
     if [ -d "${DOTFILES}/${item}" ]; then
       packages=$((packages + 1))
       if [[ "${DRY_RUN}" == "true" ]]; then
@@ -184,15 +240,21 @@ main() {
     fi
   fi
 
+  # Platform-aware next steps
   printf "\n[DOTFILES] Setup complete!\n\n"
 
   echo "Next steps:"
   echo "  -> Install Zap: https://www.zapzsh.com"
-  echo "  -> Install packages: brew bundle install --file=${DOTFILES}/brew/Brewfile"
+  if [[ "${PROFILE}" == "macos" ]]; then
+    echo "  -> Install packages: brew bundle install --file=${DOTFILES}/brew/Brewfile"
+  fi
   echo "  -> Install Tmux plugins: <prefix> + I"
   echo "  -> Create ~/.zshrc.local for machine-specific overrides"
   echo "  -> Create ~/.secrets with OP_SERVICE_ACCOUNT_TOKEN for 1Password"
   echo "  -> Run 'secrets --load' to configure vault/item and populate ~/.vars"
+  if [[ "${PROFILE}" == "desktop" ]]; then
+    echo "  -> Build Ghostty from source: https://github.com/ghostty-org/ghostty"
+  fi
   echo ""
 }
 

--- a/shared/environment.sh
+++ b/shared/environment.sh
@@ -4,9 +4,12 @@
 #
 # Usage: source ~/dotfiles/shared/environment.sh
 
-# BSD ls colors
-export CLICOLOR=1
-export LSCOLORS=GxFxCxDxBxegedabagaced
+# macOS-only settings
+if [[ "$(uname)" == "Darwin" ]]; then
+  export CLICOLOR=1
+  export LSCOLORS=GxFxCxDxBxegedabagaced
+  export HOMEBREW_CASK_OPTS="--appdir=/Applications"
+fi
 
 # Editor
 export EDITOR="nvim"
@@ -15,9 +18,6 @@ export BUNDLER_EDITOR="${EDITOR}"
 
 # Manual pages
 export MANPAGER="less -X"
-
-# Homebrew
-export HOMEBREW_CASK_OPTS="--appdir=/Applications"
 
 # XDG Base Directory
 export XDG_CONFIG_HOME="${HOME}/.config"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,8 +1,10 @@
-# Homebrew
-if [[ "$(arch)" == arm64 ]]; then
-  eval "$(/opt/homebrew/bin/brew shellenv)"
-else
-  eval "$(/usr/local/bin/brew shellenv)"
+# Homebrew (macOS only)
+if [[ "$(uname)" == "Darwin" ]]; then
+  if [[ "$(arch)" == arm64 ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  else
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
 fi
 
 export PATH="$HOME/.local/bin:$PATH"
@@ -39,7 +41,7 @@ setopt HIST_VERIFY
 setopt INC_APPEND_HISTORY
 setopt SHARE_HISTORY
 
-# Homebrew completions
+# Homebrew completions (macOS)
 if type brew &>/dev/null; then
   FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
 fi
@@ -56,11 +58,21 @@ fi
 typeset -U path
 
 # Starship prompt
-eval "$(starship init zsh)"
+if command -v starship &>/dev/null; then
+  eval "$(starship init zsh)"
+fi
 
 # zoxide (smarter cd)
-eval "$(zoxide init zsh)"
+if command -v zoxide &>/dev/null; then
+  eval "$(zoxide init zsh)"
+fi
 
 # fzf key bindings and completion
-[[ -f "${HOMEBREW_PREFIX}/opt/fzf/shell/key-bindings.zsh" ]] && source "${HOMEBREW_PREFIX}/opt/fzf/shell/key-bindings.zsh"
-[[ -f "${HOMEBREW_PREFIX}/opt/fzf/shell/completion.zsh" ]] && source "${HOMEBREW_PREFIX}/opt/fzf/shell/completion.zsh"
+for _fzf_file in \
+  "${HOMEBREW_PREFIX:-}/opt/fzf/shell/key-bindings.zsh" \
+  "${HOMEBREW_PREFIX:-}/opt/fzf/shell/completion.zsh" \
+  "/usr/share/doc/fzf/examples/key-bindings.zsh" \
+  "/usr/share/doc/fzf/examples/completion.zsh"; do
+  [[ -f "$_fzf_file" ]] && source "$_fzf_file"
+done
+unset _fzf_file


### PR DESCRIPTION
## Description

Add Debian Linux support (server, desktop, WSL profiles) to the dotfiles project. A single `./setup.sh` entry point detects the platform and produces a working dev environment on both macOS and Debian.

## Type of Change

- [x] New feature

## Changes Made

- `setup.sh`: OS detection, `--profile` flag (server/desktop/wsl), profile-based stow package selection, platform-aware messages
- `scripts/install-packages.sh`: New Debian installer — apt packages, Neovim AppImage, Starship, mise, eza, GitHub CLI, 1Password CLI, diff-so-fancy, lazygit, shfmt, and more. Architecture-aware (amd64/arm64)
- `zsh/.zshrc`: Guard Homebrew init for macOS, add Debian fzf paths, guard starship/zoxide init
- `shared/environment.sh`: Guard macOS-only vars (CLICOLOR, LSCOLORS, HOMEBREW_CASK_OPTS)
- `secrets/.local/bin/secrets`: Platform-aware `stat` and `sed -i`, platform-aware install hints
- `.gitignore`: Fix `*.local` pattern that blocked `secrets/.local/` from tracking
- `.stow-local-ignore`: Exclude plan directory from stow

## Testing

```bash
# macOS (no behavior change)
./setup.sh --dry-run

# Debian
./setup.sh --dry-run --profile server
./setup.sh --dry-run --profile desktop

# Verify profile validation
./setup.sh --profile invalid  # should error
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed
- [x] All scripts pass shellcheck