### PR TITLE
feat: warn when using personal email in git setup

### DIFF
--- a/scripts/git-setup.sh
+++ b/scripts/git-setup.sh
@@ -82,6 +82,21 @@ prompt_identity() {
     error "Name and email are required"
     exit 1
   fi
+
+  # Warn if using a personal email instead of GitHub noreply
+  if [[ "${EMAIL}" != *"@users.noreply.github.com" ]]; then
+    warn "Using a personal email exposes it in every commit"
+    info "  Recommended: use your GitHub noreply address"
+    info "  Format: <id>+<username>@users.noreply.github.com"
+    info "  Find yours at: https://github.com/settings/emails"
+    printf "  Continue with '%s'? [y/N]: " "${EMAIL}"
+    local confirm
+    read -r confirm
+    if [[ "${confirm}" != [yY] ]]; then
+      info "Aborted — re-run with your noreply email"
+      exit 0
+    fi
+  fi
 }
 
 ensure_ssh_key() {


### PR DESCRIPTION
## Description

Adds a privacy warning to `git-setup.sh` when a user enters a personal email instead of their GitHub noreply address. Prompts for confirmation before proceeding.

## Type of Change

- [x] New feature

## Changes Made

- Detect non-noreply email addresses during git identity setup
- Display warning with recommended noreply format and GitHub settings link
- Prompt user to confirm or abort and re-run with noreply email

## Testing

Run `scripts/git-setup.sh` and enter a personal email — verify the warning appears and confirmation prompt works.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed