### PR TITLE
feat: enable word wrap for markdown and prose filetypes

### DIFF
--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -42,6 +42,16 @@ vim.keymap.set("n", "<C-l>", "<C-w><C-l>", { desc = "Move focus right" })
 vim.keymap.set("n", "<C-j>", "<C-w><C-j>", { desc = "Move focus down" })
 vim.keymap.set("n", "<C-k>", "<C-w><C-k>", { desc = "Move focus up" })
 
+-- Word wrap for prose filetypes
+vim.api.nvim_create_autocmd("FileType", {
+  group = vim.api.nvim_create_augroup("prose-wrap", { clear = true }),
+  pattern = { "markdown", "text", "gitcommit" },
+  callback = function()
+    vim.opt_local.wrap = true
+    vim.opt_local.linebreak = true
+  end,
+})
+
 -- Highlight on yank
 vim.api.nvim_create_autocmd("TextYankPost", {
   group = vim.api.nvim_create_augroup("highlight-yank", { clear = true }),


### PR DESCRIPTION
## Description

Adds a filetype autocommand to enable word wrap and linebreak for markdown, text, and gitcommit files. The global `wrap = false` stays intact for code files.

## Type of Change

- [x] New feature

## Changes Made

- Added `prose-wrap` autocommand group in `nvim/.config/nvim/init.lua`
- Sets `wrap` and `linebreak` locally for markdown, text, and gitcommit filetypes

## Testing

Open a markdown file in neovim and confirm long lines wrap at word boundaries.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed