### PR TITLE
feat: add split management keybindings to ghostty

### DIFF
--- a/ghostty/.config/ghostty/config
+++ b/ghostty/.config/ghostty/config
@@ -38,3 +38,8 @@ copy-on-select = true
 auto-update = check
 auto-update-channel = stable
 confirm-close-surface = false
+
+# Keybindings
+keybind = ctrl+shift+p=new_split:right
+keybind = ctrl+shift+h=goto_split:left
+keybind = ctrl+shift+l=goto_split:right


### PR DESCRIPTION
## Description

Add keybindings for Ghostty split management: create right split, and navigate between left/right splits.

## Type of Change

- [x] New feature

## Changes Made

- `ctrl+shift+p` to create a new split to the right
- `ctrl+shift+h` to navigate to the left split
- `ctrl+shift+l` to navigate to the right split

## Testing

Reload Ghostty config with `shift+cmd+,` and test each keybinding.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed