### PR TITLE
feat: close remaining gaps for Debian daily-driver parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,16 +4,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-macOS dotfiles managed with [GNU Stow](https://www.gnu.org/software/stow/). Each top-level directory is a stow package that mirrors the target home directory structure. Stow creates symlinks from `~/dotfiles/<package>/...` into `$HOME/...`.
+macOS and Debian dotfiles managed with [GNU Stow](https://www.gnu.org/software/stow/). Each top-level directory is a stow package that mirrors the target home directory structure. Stow creates symlinks from `~/dotfiles/<package>/...` into `$HOME/...`. `setup.sh` auto-detects the OS via `uname -s`.
 
 ## Setup
 
 ```bash
-./setup.sh            # symlink all packages via stow
-./setup.sh --dry-run  # preview without changes
+./setup.sh                       # macOS: symlink packages (auto-detected)
+./setup.sh --profile desktop     # Debian daily-driver: CLI + Ghostty + fonts
+./setup.sh --profile server      # Debian headless / CLI-only (default on Linux)
+./setup.sh --profile wsl         # Windows Subsystem for Linux
+./setup.sh --dry-run             # preview without changes (any profile)
 ```
 
-After setup, install dependencies:
+On Linux, `setup.sh` invokes `scripts/install-packages.sh --profile <name>` automatically — installs apt packages plus alternative installers for Starship, mise, lazygit, eza, gh, 1Password CLI, and (for `desktop`) Ghostty via the [debian.griffo.io](https://debian.griffo.io/install-latest-ghostty-in-debian.html) apt repo and JetBrains Mono Nerd Font.
+
+On macOS, install CLI tools and casks separately:
 ```bash
 brew bundle install --file=~/dotfiles/brew/Brewfile
 ```
@@ -22,8 +27,8 @@ brew bundle install --file=~/dotfiles/brew/Brewfile
 
 | Package | Target | What it configures |
 |---------|--------|--------------------|
-| `brew` | (not stowed) | Brewfile with CLI tools, dev dependencies, fonts |
-| `ghostty` | `~/.config/ghostty/` | Ghostty terminal (Everforest Dark Hard, cursor smear shader) |
+| `brew` | (not stowed, macOS only) | Brewfile with CLI tools, dev dependencies, fonts |
+| `ghostty` | `~/.config/ghostty/` | Ghostty terminal (Everforest Dark Hard, cursor smear shader); stowed on `desktop` profile only on Linux |
 | `git` | `~/.gitconfig`, `~/.gitignore_global`, `~/.gitmessage` | Git config with SSH signing, diff-so-fancy (identity via `scripts/git-setup.sh`) |
 | `nvim` | `~/.config/nvim/` | Neovim with lazy.nvim plugin manager |
 | `secrets` | `~/.local/bin/secrets` | 1Password CLI secrets loader (`secrets --load`, `--show`) |
@@ -34,6 +39,8 @@ brew bundle install --file=~/dotfiles/brew/Brewfile
 ## Architecture
 
 - **Stow convention**: Files inside each package directory are placed relative to `$HOME`. For example, `git/.gitconfig` becomes `~/.gitconfig`, and `nvim/.config/nvim/init.lua` becomes `~/.config/nvim/init.lua`.
+- **OS detection**: `setup.sh` reads `uname -s` and branches between macOS and Linux. On Linux, `--profile {server|desktop|wsl}` selects which stow packages to apply (`server`/`wsl` skip `ghostty`); when omitted, defaults to `server` and prints a hint about `--profile desktop`. macOS-specific bits in shell config and `shared/environment.sh` are gated with `[[ "$(uname)" == "Darwin" ]]`.
+- **`scripts/install-packages.sh`**: Debian package installer invoked by `setup.sh` on Linux. Installs apt packages (including `xclip` and `wl-clipboard` for tmux clipboard integration) and alternative installers for tools not in apt (Starship, mise, eza, gh, 1Password CLI, lazygit, shfmt, tealdeer, yq, fastfetch, JetBrains Mono Nerd Font, and Ghostty on `desktop`).
 - **`.stow-local-ignore`**: Excludes repo-level files (setup.sh, shared/, README, etc.) from stow operations.
 - **`shared/environment.sh`**: Shared env vars sourced by `.zshrc` (not stowed directly). Sets XDG dirs, editor, FZF config.
 - **Local overrides**: `~/.zshrc.local` and `~/.gitconfig.local` are sourced but gitignored (`*.local` pattern). Machine-specific config goes there.

--- a/README.md
+++ b/README.md
@@ -7,30 +7,45 @@
 ```
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![macOS](https://img.shields.io/badge/macOS-only-blue)](https://github.com/wcollins/dotfiles)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Debian-blue)](https://github.com/wcollins/dotfiles)
 [![Shell: Zsh](https://img.shields.io/badge/shell-zsh-green)](https://github.com/wcollins/dotfiles)
 [![Editor: Neovim](https://img.shields.io/badge/editor-neovim-57A143)](https://neovim.io)
 
-> macOS dotfiles managed with GNU Stow. Everforest theme everywhere.
+> macOS and Debian dotfiles managed with GNU Stow. Everforest theme everywhere.
 
 Ghostty + Neovim + Tmux + Zsh + Starship — consistent Everforest Dark palette across everything.
 
 ## Quick Start
 
-Requires macOS, [Homebrew](https://brew.sh), and [GNU Stow](https://www.gnu.org/software/stow/) (`brew install stow`).
+[GNU Stow](https://www.gnu.org/software/stow/) is required on both platforms. `setup.sh` auto-detects the OS.
+
+### macOS
+
+Requires [Homebrew](https://brew.sh) (`brew install stow`).
 
 ```bash
 git clone https://github.com/wcollins/dotfiles.git ~/dotfiles
 cd ~/dotfiles
 
-./setup.sh            # symlink packages into ~
-./setup.sh --dry-run  # preview first
+./setup.sh                            # symlink packages into ~
+./setup.sh --dry-run                  # preview first
+
+brew bundle install --file=brew/Brewfile  # install CLI tools, fonts, Ghostty
 ```
 
-Then install dependencies:
+### Debian
+
+Requires `sudo` access. `setup.sh` runs `scripts/install-packages.sh` automatically — installs CLI tools via apt plus alternative installers for Starship, mise, lazygit, etc.
 
 ```bash
-brew bundle install --file=~/dotfiles/brew/Brewfile
+git clone https://github.com/wcollins/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+sudo apt install -y stow
+
+./setup.sh --profile desktop          # daily-driver: GUI, Ghostty, Nerd Fonts
+./setup.sh --profile server           # headless / CLI-only (default if --profile omitted)
+./setup.sh --profile wsl              # Windows Subsystem for Linux
+./setup.sh --profile desktop --dry-run  # preview first
 ```
 
 > [!NOTE]
@@ -42,8 +57,8 @@ Each directory is a [GNU Stow](https://www.gnu.org/software/stow/) package — f
 
 | Package | What it configures |
 |---------|--------------------|
-| `brew` | Brewfile — fzf, ripgrep, eza, lazygit, bat, zoxide, and more |
-| `ghostty` | Ghostty terminal — Everforest Dark Hard, MesloLGS Nerd Font, cursor smear shader |
+| `brew` | Brewfile — fzf, ripgrep, eza, lazygit, bat, zoxide, and more (macOS only) |
+| `ghostty` | Ghostty terminal — Everforest Dark Hard, JetBrains Mono Nerd Font, cursor smear shader |
 | `git` | Git config with SSH commit signing, diff-so-fancy, aliases |
 | `nvim` | Neovim with lazy.nvim |
 | `secrets` | 1Password CLI secrets loader (configurable vault/item) |

--- a/ghostty/.config/ghostty/config
+++ b/ghostty/.config/ghostty/config
@@ -30,7 +30,7 @@ mouse-hide-while-typing = true
 custom-shader-animation = true
 
 # Text settings
-font-family = MesloLGS Nerd Font Mono
+font-family = JetBrainsMono Nerd Font Mono
 font-size = 14
 copy-on-select = true
 

--- a/scripts/install-packages.sh
+++ b/scripts/install-packages.sh
@@ -67,6 +67,8 @@ install_apt_packages() {
     tmux
     tree
     wget
+    wl-clipboard
+    xclip
     zsh
     zoxide
   )
@@ -312,6 +314,36 @@ install_fastfetch() {
   rm -rf "${tmp}"
 }
 
+# --- Ghostty (desktop only) --------------------------------------------------
+
+install_ghostty() {
+  if command -v ghostty &>/dev/null; then
+    info "Ghostty already installed"
+    return 0
+  fi
+  info "Installing Ghostty..."
+
+  local codename
+  # shellcheck source=/dev/null
+  codename=$(. /etc/os-release && echo "${VERSION_CODENAME:-stable}")
+
+  sudo mkdir -p /etc/apt/keyrings
+  if ! curl -fsSL https://debian.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc \
+    | sudo gpg --dearmor --yes -o /etc/apt/keyrings/ghostty.gpg; then
+    warn "Failed to fetch Ghostty signing key; skipping Ghostty install"
+    warn "See https://debian.griffo.io/install-latest-ghostty-in-debian.html"
+    return 1
+  fi
+  echo "deb [signed-by=/etc/apt/keyrings/ghostty.gpg] https://debian.griffo.io/apt ${codename} main" \
+    | sudo tee /etc/apt/sources.list.d/ghostty.list >/dev/null
+  sudo apt update -qq
+  if ! sudo apt install -y ghostty; then
+    warn "Failed to install ghostty via apt; skipping"
+    warn "See https://debian.griffo.io/install-latest-ghostty-in-debian.html"
+    return 1
+  fi
+}
+
 # --- Nerd Fonts (desktop only) -----------------------------------------------
 
 install_fonts() {
@@ -370,6 +402,7 @@ main() {
 
   # Desktop-only packages
   if [[ "${PROFILE}" == "desktop" ]]; then
+    install_ghostty || warn "Continuing without Ghostty"
     install_fonts
   fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -88,8 +88,13 @@ resolve_profile() {
       exit 1
     fi
     PROFILE="macos"
+  elif [[ "${PROFILE}" == "macos" ]]; then
+    error "--profile macos is auto-detected and only valid on Darwin"
+    exit 1
   elif [[ -z "${PROFILE}" ]]; then
     PROFILE="server"
+    info "Linux detected with no --profile; defaulting to 'server' (CLI-only)."
+    info "For full desktop parity (Ghostty + fonts), re-run with: ./setup.sh --profile desktop"
   fi
 
   case "${PROFILE}" in
@@ -253,7 +258,7 @@ main() {
   echo "  -> Create ~/.secrets with OP_SERVICE_ACCOUNT_TOKEN for 1Password"
   echo "  -> Run 'secrets --load' to configure vault/item and populate ~/.vars"
   if [[ "${PROFILE}" == "desktop" ]]; then
-    echo "  -> Build Ghostty from source: https://github.com/ghostty-org/ghostty"
+    echo "  -> Launch Ghostty and verify font + glyphs render correctly"
   fi
   echo ""
 }


### PR DESCRIPTION
## Description

Closes the remaining gaps from the prior Debian Linux-compat work so Debian becomes a true daily-driver target. All changes are additive and gated to Linux paths — macOS behavior is unchanged outside the Ghostty font-family alignment.

## Type of Change

- [x] New feature (non-breaking polish on existing functionality)

## Changes Made

- **Ghostty font alignment**: `font-family` → `JetBrainsMono Nerd Font Mono` so it matches what the Brewfile and `install-packages.sh` actually install.
- **Clipboard on Debian**: added `xclip` and `wl-clipboard` to the apt package list — `tmux-yank` now reaches the system clipboard on both X11 and Wayland.
- **Ghostty on Debian**: new `install_ghostty()` in `scripts/install-packages.sh` using the [debian.griffo.io](https://debian.griffo.io/install-latest-ghostty-in-debian.html) apt repo (same signed-keyring pattern as `install_eza`/`install_gh`/`install_op`). Gated on `--profile desktop`. Gracefully degrades on failure.
- **Linux profile UX**: when Linux is detected without `--profile`, `setup.sh` defaults to `server` and prints a hint pointing to `--profile desktop` for full GUI parity. Also rejects `--profile macos` on Linux (was silently accepted, skipping installer). Stale "Build Ghostty from source" post-install hint replaced with a font/glyph sanity-check reminder.
- **README**: badge `macOS-only` → `macOS | Debian`; Quick Start now shows parallel macOS and Debian sections including `--profile {desktop|server|wsl}`.
- **AGENTS.md**: Overview, Setup, and Architecture sections reflect both platforms and document `install-packages.sh` and the profile system.

## Testing

- `shellcheck setup.sh scripts/install-packages.sh` → no new warnings (pre-existing SC2155 in `backup_conflict` remains).
- `./setup.sh --profile desktop --dry-run` → runs cleanly, would invoke installer.
- `./setup.sh --dry-run` (no `--profile`) → defaults to `server` and prints the discoverability hint.
- `./setup.sh --profile macos` on Linux → rejected with exit 1.
- macOS path: untouched outside the font-family change (which works on macOS via the existing `font-jetbrains-mono-nerd-font` Brewfile entry).

A full live `./setup.sh --profile desktop` on this Debian box is recommended before merge to confirm Ghostty apt install completes end-to-end.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #9