### PR TITLE
fix: install diff-so-fancy to user prefix

### DIFF
--- a/scripts/install-packages.sh
+++ b/scripts/install-packages.sh
@@ -208,7 +208,7 @@ install_diff_so_fancy() {
     return
   fi
   info "Installing diff-so-fancy..."
-  npm install -g diff-so-fancy
+  npm install -g --prefix="${HOME}/.local" diff-so-fancy
 }
 
 # --- lazygit -----------------------------------------------------------------


### PR DESCRIPTION
## Description

`npm install -g diff-so-fancy` failed with `EACCES` on Debian because the system npm writes to `/usr/lib/node_modules` (root-owned). Since `install-packages.sh` runs under `set -euo pipefail`, the error aborted the rest of the installer (Ghostty, fonts) on the `desktop` profile.

## Type of Change

- [x] Bug fix

## Changes Made

- Pass `--prefix="${HOME}/.local"` to `npm install -g` so the package lands in `~/.local/lib/node_modules` and the binary is symlinked into `~/.local/bin/diff-so-fancy` — matching the user-level install pattern already used elsewhere in the script

## Testing

- `./setup.sh --profile desktop` on Debian completes past the diff-so-fancy step without sudo
- `which diff-so-fancy` resolves to `~/.local/bin/diff-so-fancy`
- `shellcheck scripts/install-packages.sh` clean

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed