### PR TITLE
feat: switch default shell to zsh during Debian setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ macOS and Debian dotfiles managed with [GNU Stow](https://www.gnu.org/software/s
 
 On Linux, `setup.sh` invokes `scripts/install-packages.sh --profile <name>` automatically — installs apt packages plus alternative installers for Starship, mise, lazygit, eza, gh, 1Password CLI, and (for `desktop`) Ghostty via the [debian.griffo.io](https://debian.griffo.io/install-latest-ghostty-in-debian.html) apt repo and JetBrains Mono Nerd Font.
 
+On Linux, setup also offers to make zsh your default login shell — an interactive `Make zsh your default shell? [Y/n]` prompt (default Yes) that runs `chsh`. Installing the `zsh` package alone does not change your login shell, so without this the zsh config never loads on a fresh Debian box. The prompt is skipped under `--dry-run` or when stdin is not a TTY, is idempotent (skips if the login shell is already zsh), and never aborts setup if `chsh` fails. After a switch, log out and back in (or open a new terminal) for zsh to take effect.
+
 On macOS, install CLI tools and casks separately:
 ```bash
 brew bundle install --file=~/dotfiles/brew/Brewfile
@@ -45,6 +47,7 @@ brew bundle install --file=~/dotfiles/brew/Brewfile
 - **`shared/environment.sh`**: Shared env vars sourced by `.zshrc` (not stowed directly). Sets XDG dirs, editor, FZF config.
 - **Local overrides**: `~/.zshrc.local` and `~/.gitconfig.local` are sourced but gitignored (`*.local` pattern). Machine-specific config goes there.
 - **Git signing**: Commits are signed using SSH keys. Run `scripts/git-setup.sh` to configure identity and signing key (called automatically by `setup.sh`). The `[user]` section and signing key are stored in `~/.gitconfig.local` (gitignored). To reconfigure: `scripts/git-setup.sh`. To verify: `scripts/git-setup.sh --check`.
+- **Default shell**: `setup.sh::switch_default_shell()` runs on Linux after stow/git-setup and before the "Next steps" block. It reads the current login shell from `getent passwd "$USER"` (field 7, not `$SHELL`); if it isn't zsh, it prompts `Make zsh your default shell? [Y/n]` (default Yes) and switches via `sudo chsh`. It is idempotent (skips when already zsh), treats non-TTY and `--dry-run` as No, ensures the resolved zsh path is in `/etc/shells` (appending via `sudo` as a safety net), and on failure `warn`s with the manual `chsh` command without aborting setup. A successful switch appends a re-login reminder to "Next steps"; the `wsl` profile additionally notes the Windows terminal may launch a different shell regardless of `chsh`.
 - **mise**: Runtime version manager activated in `.zshrc` (guarded). Manages Go, Node, and other tool versions per-project. Installed via Brewfile.
 - **secrets**: `secrets --load` reads `OP_SERVICE_ACCOUNT_TOKEN`, `VAULT`, and `ITEM` from `~/.secrets`, fetches env vars from 1Password, and writes exports to `~/.vars`. On first run, prompts for vault and item names and saves them. Use `--vault`/`--item` flags for one-time overrides. The `.zshrc` sources `~/.vars` automatically. Both `~/.secrets` and `~/.vars` are local-only (not committed).
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ sudo apt install -y stow
 > [!NOTE]
 > Install [Zap](https://www.zapzsh.com) for zsh plugin management. Tmux plugins install with `<prefix> + I` after first launch.
 
+> [!TIP]
+> On Linux, setup offers to make zsh your default login shell (`Make zsh your default shell? [Y/n]`, default Yes). Installing the `zsh` package doesn't change your login shell on its own, so accept this to have the config load on a fresh box — then log out and back in. It's idempotent and skipped under `--dry-run` or non-interactive runs.
+
 ## What's Inside
 
 Each directory is a [GNU Stow](https://www.gnu.org/software/stow/) package — files mirror their target location under `$HOME`.
@@ -81,6 +84,7 @@ Machine-specific config goes in these files (gitignored via `*.local`):
 - Create `~/.zshrc.local` for machine-specific shell config
 - Install tmux plugins: open tmux, press `C-a` then `I`
 - For 1Password secrets: create `~/.secrets` with `OP_SERVICE_ACCOUNT_TOKEN`, then run `secrets --load`
+- On Linux, if you accepted the default-shell prompt, log out and back in (or open a new terminal) so zsh becomes active
 
 ## License
 MIT - Do whatever you want with it

--- a/setup.sh
+++ b/setup.sh
@@ -20,6 +20,7 @@ DRY_RUN=false
 DOTFILES="${HOME}/dotfiles"
 OS=$(uname -s)
 PROFILE=""
+SHELL_SWITCHED=false
 
 show_help() {
   cat <<EOF
@@ -101,6 +102,68 @@ resolve_profile() {
     macos|server|desktop|wsl) ;;
     *) error "Invalid profile: ${PROFILE}. Must be: server, desktop, or wsl"; exit 1 ;;
   esac
+}
+
+# Offer to make zsh the default login shell (Linux only, idempotent).
+switch_default_shell() {
+  # macOS already defaults to zsh; nothing to do.
+  [[ "${OS}" == "Linux" ]] || return 0
+
+  # Read the configured login shell from passwd (field 7), not $SHELL,
+  # which reflects the invoking shell rather than the login shell.
+  local current_shell
+  current_shell=$(getent passwd "${USER}" | cut -d: -f7) || current_shell=""
+  if [[ "${current_shell}" == *zsh ]]; then
+    info "Login shell already zsh; skipping."
+    return 0
+  fi
+
+  local zsh_path
+  if ! zsh_path=$(command -v zsh); then
+    warn "zsh not found on PATH; skipping default-shell switch."
+    return 0
+  fi
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    info "[DRY RUN] Would change login shell to ${zsh_path}"
+    return 0
+  fi
+
+  # Non-interactive runs default to No so setup never blocks on input.
+  if [[ ! -t 0 ]]; then
+    info "Non-interactive; keeping current shell. To switch later: chsh -s ${zsh_path}"
+    return 0
+  fi
+
+  local reply=""
+  read -r -p "Make zsh your default shell? [Y/n] " reply || true
+  case "${reply}" in
+    "" | [Yy] | [Yy][Ee][Ss]) ;;
+    *)
+      info "Keeping current shell. To switch later: chsh -s ${zsh_path}"
+      return 0
+      ;;
+  esac
+
+  # zsh must be a valid login shell; append as a safety net (present on trixie).
+  if ! grep -qxF "${zsh_path}" /etc/shells 2>/dev/null; then
+    if ! echo "${zsh_path}" | sudo tee -a /etc/shells >/dev/null; then
+      warn "Could not add ${zsh_path} to /etc/shells; skipping default-shell switch."
+      return 0
+    fi
+  fi
+
+  # sudo keeps chsh non-interactive, consistent with the rest of the installer.
+  if sudo chsh -s "${zsh_path}" "${USER}"; then
+    SHELL_SWITCHED=true
+    info "Default shell changed to zsh."
+    if [[ "${PROFILE}" == "wsl" ]]; then
+      info "WSL: the Windows terminal may launch a different shell regardless of chsh."
+      info "If zsh doesn't start automatically, set it in your terminal profile or /etc/wsl.conf."
+    fi
+  else
+    warn "Failed to change login shell. To switch manually: chsh -s ${zsh_path}"
+  fi
 }
 
 main() {
@@ -245,6 +308,9 @@ main() {
     fi
   fi
 
+  # Offer to switch the default login shell to zsh (Linux only)
+  switch_default_shell
+
   # Platform-aware next steps
   printf "\n[DOTFILES] Setup complete!\n\n"
 
@@ -259,6 +325,9 @@ main() {
   echo "  -> Run 'secrets --load' to configure vault/item and populate ~/.vars"
   if [[ "${PROFILE}" == "desktop" ]]; then
     echo "  -> Launch Ghostty and verify font + glyphs render correctly"
+  fi
+  if [[ "${SHELL_SWITCHED}" == "true" ]]; then
+    echo "  -> Default shell changed to zsh — log out and back in (or open a new terminal)"
   fi
   echo ""
 }


### PR DESCRIPTION
## Description

Adds a guarded, idempotent step to the Linux path of `setup.sh` that offers to make zsh the user's default login shell via `chsh`. Installing the `zsh` package alone never changes the login shell, so on a fresh Debian box the entire zsh config (aliases, functions, plugins) silently never loads — this fixes that.

## Type of Change

- [x] New feature (`feat`)

## Changes Made

- New `switch_default_shell()` in `setup.sh`: detects the login shell via `getent passwd "$USER"` (not `$SHELL`), prompts `Make zsh your default shell? [Y/n]` (default Yes), and switches with `sudo chsh`.
- Idempotent (skips when already zsh); treats non-TTY and `--dry-run` as No; ensures the zsh path is in `/etc/shells`; warns and continues if `chsh` fails (never aborts setup).
- Re-login reminder appended to "Next steps" on success; extra WSL terminal note on the `wsl` profile.
- Documented the new prompt/behavior in `AGENTS.md` and `README.md`.

## Testing

- `shellcheck setup.sh` — no new findings (one pre-existing SC2155 unrelated to this change); `bash -n setup.sh` clean.
- Exercised every path in an isolated PTY harness (stubbed `chsh`/`sudo`): macOS gate, already-zsh, dry-run, non-TTY, decline, accept (empty/`y`/`yes`), WSL note, and `chsh` failure — `ERR` trap never fires.
- `./setup.sh --dry-run --profile server` reports the intended change without prompting or executing `chsh`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #12