### PR TITLE
fix: reset terminal modes after ssh exits

### DIFF
--- a/zsh/.config/zsh/functions.zsh
+++ b/zsh/.config/zsh/functions.zsh
@@ -47,3 +47,15 @@ note() {
     $EDITOR "$notes_dir/$1.md"
   fi
 }
+
+# Reset terminal modes after ssh exits; an unclean disconnect leaves
+# mouse tracking enabled by remote tmux/nvim, spraying escape codes
+ssh() {
+  local ret
+  command ssh "$@"
+  ret=$?
+  if [[ -t 1 ]]; then
+    printf '\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?1004l\e[?25h'
+  fi
+  return $ret
+}


### PR DESCRIPTION
## Description

After an SSH session dies uncleanly (broken pipe), a remote tmux or nvim leaves SGR mouse tracking enabled in the local terminal, so mouse movement sprays sequences like `35;77;3M` into the prompt. This adds an `ssh` wrapper that disables mouse tracking (modes 1000/1002/1003/1006), focus reporting (1004), and restores the cursor after every ssh exit.

## Type of Change

- [x] Bug fix

## Changes Made

- Add `ssh()` wrapper to `zsh/.config/zsh/functions.zsh`: runs `command ssh "$@"`, emits mode-disable sequences only when stdout is a TTY, and preserves ssh's exit status

## Testing

- `zsh -n zsh/.config/zsh/functions.zsh` parses cleanly
- Exit status passthrough verified (`ssh invalid.host true` returns 255 through the wrapper)
- Piped output is byte-identical to plain ssh (zero bytes emitted when stdout is not a TTY)
- Pty test via `script(1)` confirms disable sequences are emitted on the TTY path
- scp, rsync, and git are unaffected (they exec the ssh binary directly)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #16